### PR TITLE
Export Cache Manager

### DIFF
--- a/lib/firebase_image.dart
+++ b/lib/firebase_image.dart
@@ -2,3 +2,5 @@ library firebase_image;
 
 export 'src/firebase_image.dart';
 export 'src/cache_refresh_strategy.dart';
+export 'src/cache_manager.dart';
+  


### PR DESCRIPTION
this will allow a user to make manual database changes. i ran into an issue where i am updating a remote image, but the cache is holding onto the old reference