### PR TITLE
Add Delete Method & Account for Firebase Error

### DIFF
--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -135,8 +135,13 @@ class FirebaseImageCacheManager {
   }
 
   Future<Uint8List> remoteFileBytes(
-      FirebaseImageObject object, int maxSizeBytes) {
-    return object.reference.getData(maxSizeBytes);
+      FirebaseImageObject object, int maxSizeBytes) async {
+    Directory dir = await getApplicationSupportDirectory();
+    File file = File('${dir.path}/${object.remotePath}');
+    file.createSync(recursive: true);
+    StorageFileDownloadTask task = object.reference.writeToFile(file);
+    await task.future;
+    return file.readAsBytesSync();
   }
 
   Future<Uint8List> upsertRemoteFileToCache(

--- a/lib/src/firebase_image.dart
+++ b/lib/src/firebase_image.dart
@@ -111,6 +111,17 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
         .instantiateImageCodec(await _fetchImage());
   }
 
+  Future<bool> delete() async {
+    FirebaseImageCacheManager cacheManager = new FirebaseImageCacheManager(
+      cacheRefreshStrategy,
+    );
+
+    await cacheManager.open();
+    await cacheManager.delete(_imageObject.uri);
+
+    return super.evict();
+  }
+
   @override
   Future<FirebaseImage> obtainKey(ImageConfiguration configuration) {
     return SynchronousFuture<FirebaseImage>(this);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -252,6 +252,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.15"
+  transparent_image:
+    dependency: "direct main"
+    description:
+      name: transparent_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   sqflite: ^1.1.6+5
   path: ^1.6.4
   path_provider: ^1.3.0
+  transparent_image: 1.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- when firebase storage throws an error, return a transparent image
- add in a delete method to Firebase image which evicts from the cache and deletes from the db
- when gettig remote image, do a write instead of a get to avoid size limits

closes #11 