### PR TITLE
ImageFetchStrategy and On Error Handling

### DIFF
--- a/lib/firebase_image.dart
+++ b/lib/firebase_image.dart
@@ -2,3 +2,4 @@ library firebase_image;
 
 export 'src/firebase_image.dart';
 export 'src/cache_refresh_strategy.dart';
+export 'src/image_fetch_strategy.dart';

--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -6,9 +6,12 @@ import 'package:firebase_image/src/firebase_image.dart';
 import 'package:firebase_image/src/image_object.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart';
+
+import 'image_fetch_strategy.dart';
 
 class FirebaseImageCacheManager {
   static const String key = 'firebase_image';
@@ -19,10 +22,12 @@ class FirebaseImageCacheManager {
   String basePath;
 
   final CacheRefreshStrategy cacheRefreshStrategy;
+  final ImageFetchStrategy imageFetchStrategy;
 
-  FirebaseImageCacheManager(
-    this.cacheRefreshStrategy,
-  );
+  FirebaseImageCacheManager({
+    @required this.cacheRefreshStrategy,
+    this.imageFetchStrategy = ImageFetchStrategy.FETCH_TO_MEMORY,
+  }) : assert(cacheRefreshStrategy != null);
 
   Future<void> open() async {
     db = await openDatabase(
@@ -138,9 +143,28 @@ class FirebaseImageCacheManager {
     return null;
   }
 
-  Future<Uint8List> remoteFileBytes(
-      FirebaseImageObject object, int maxSizeBytes) {
+  Future<Uint8List> _fetchToMemory(FirebaseImageObject object, int maxSizeBytes) {
     return object.reference.getData(maxSizeBytes);
+  }
+
+  Future<Uint8List> _fetchToFile(FirebaseImageObject object) async {
+    Directory dir = await getApplicationSupportDirectory();
+    File file = File('${dir.path}/${object.remotePath}');
+    file.createSync(recursive: true);
+    StorageFileDownloadTask task = object.reference.writeToFile(file);
+    await task.future;
+    return file.readAsBytesSync();
+  }
+
+  Future<Uint8List> remoteFileBytes(FirebaseImageObject object, int maxSizeBytes) {
+    if (imageFetchStrategy == ImageFetchStrategy.FETCH_TO_FILE) {
+      return _fetchToFile(object);
+    }
+    else if (imageFetchStrategy == ImageFetchStrategy.FETCH_TO_MEMORY) {
+      return _fetchToMemory(object, maxSizeBytes);
+    }
+
+    throw(Exception("ImageFetchStrategy missing"));
   }
 
   Future<Uint8List> upsertRemoteFileToCache(

--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -151,8 +151,8 @@ class FirebaseImageCacheManager {
     Directory dir = await getApplicationSupportDirectory();
     File file = File('${dir.path}/${object.remotePath}');
     file.createSync(recursive: true);
-    StorageFileDownloadTask task = object.reference.writeToFile(file);
-    await task.future;
+    DownloadTask task = object.reference.writeToFile(file);
+    await task;
     return file.readAsBytesSync();
   }
 

--- a/lib/src/firebase_image.dart
+++ b/lib/src/firebase_image.dart
@@ -9,6 +9,8 @@ import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import 'image_fetch_strategy.dart';
+
 class FirebaseImage extends ImageProvider<FirebaseImage> {
   // Default: True. Specified whether or not an image should be cached (optional)
   final bool shouldCache;
@@ -28,6 +30,9 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
   /// The model for the image object
   final FirebaseImageObject _imageObject;
 
+  /// Default: FETCH_TO_MEMORY. Specifies the strategy in which to fetch the image from Firebase (optional)
+  final ImageFetchStrategy imageFetchStrategy;
+
   /// Fetches, saves and returns an ImageProvider for any image in a readable Firebase Cloud Storeage bucket.
   ///
   /// [location] The URI of the image, in the bucket, to be displayed
@@ -43,6 +48,7 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
     this.maxSizeBytes = 2500 * 1000, // 2.5MB
     this.cacheRefreshStrategy = CacheRefreshStrategy.BY_METADATA_DATE,
     this.firebaseApp,
+    this.imageFetchStrategy = ImageFetchStrategy.FETCH_TO_MEMORY,
   }) : _imageObject = FirebaseImageObject(
           bucket: _getBucket(location),
           remotePath: _getImagePath(location),
@@ -73,7 +79,8 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
   Future<Uint8List> _fetchImage() async {
     Uint8List bytes;
     FirebaseImageCacheManager cacheManager = FirebaseImageCacheManager(
-      cacheRefreshStrategy,
+      cacheRefreshStrategy: cacheRefreshStrategy,
+      imageFetchStrategy: imageFetchStrategy,
     );
 
     if (shouldCache) {

--- a/lib/src/firebase_image.dart
+++ b/lib/src/firebase_image.dart
@@ -9,7 +9,10 @@ import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import 'cache_manager.dart';
 import 'image_fetch_strategy.dart';
+
+typedef FirebaseImageError = Uint8List Function(Exception exception);
 
 class FirebaseImage extends ImageProvider<FirebaseImage> {
   // Default: True. Specified whether or not an image should be cached (optional)
@@ -33,6 +36,11 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
   /// Default: FETCH_TO_MEMORY. Specifies the strategy in which to fetch the image from Firebase (optional)
   final ImageFetchStrategy imageFetchStrategy;
 
+  /// An optional response to when an error occurs (optional)
+  final FirebaseImageError onError;
+
+  final FirebaseImageCacheManager _cacheManager;
+
   /// Fetches, saves and returns an ImageProvider for any image in a readable Firebase Cloud Storeage bucket.
   ///
   /// [location] The URI of the image, in the bucket, to be displayed
@@ -49,11 +57,16 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
     this.cacheRefreshStrategy = CacheRefreshStrategy.BY_METADATA_DATE,
     this.firebaseApp,
     this.imageFetchStrategy = ImageFetchStrategy.FETCH_TO_MEMORY,
+    this.onError,
   }) : _imageObject = FirebaseImageObject(
           bucket: _getBucket(location),
           remotePath: _getImagePath(location),
           reference: _getImageRef(location, firebaseApp),
-        );
+        ),
+      _cacheManager = FirebaseImageCacheManager(
+        cacheRefreshStrategy: cacheRefreshStrategy,
+        imageFetchStrategy: imageFetchStrategy,
+      );
 
   /// Returns the image as bytes
   Future<Uint8List> getBytes() {
@@ -78,29 +91,34 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
 
   Future<Uint8List> _fetchImage() async {
     Uint8List bytes;
-    FirebaseImageCacheManager cacheManager = FirebaseImageCacheManager(
-      cacheRefreshStrategy: cacheRefreshStrategy,
-      imageFetchStrategy: imageFetchStrategy,
-    );
 
-    if (shouldCache) {
-      await cacheManager.open();
-      FirebaseImageObject localObject =
-          await cacheManager.get(_imageObject.uri, this);
+    try {
+      if (shouldCache) {
+        await _cacheManager.open();
+        FirebaseImageObject localObject =
+        await _cacheManager.get(_imageObject.uri, this);
 
-      if (localObject != null) {
-        bytes = await cacheManager.localFileBytes(localObject);
-        if (bytes == null) {
-          bytes = await cacheManager.upsertRemoteFileToCache(
+        if (localObject != null) {
+          bytes = await _cacheManager.localFileBytes(localObject);
+          if (bytes == null) {
+            bytes = await _cacheManager.upsertRemoteFileToCache(
               _imageObject, this.maxSizeBytes);
+          }
+        } else {
+          bytes = await _cacheManager.upsertRemoteFileToCache(
+            _imageObject, this.maxSizeBytes);
         }
       } else {
-        bytes = await cacheManager.upsertRemoteFileToCache(
-            _imageObject, this.maxSizeBytes);
+        bytes =
+        await _cacheManager.remoteFileBytes(_imageObject, this.maxSizeBytes);
       }
-    } else {
-      bytes =
-          await cacheManager.remoteFileBytes(_imageObject, this.maxSizeBytes);
+    }
+    catch (ex) {
+      await delete();
+
+      if (this.onError != null) {
+        bytes = this.onError(ex);
+      }
     }
 
     return bytes;
@@ -109,6 +127,13 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
   Future<Codec> _fetchImageCodec() async {
     return await PaintingBinding.instance
         .instantiateImageCodec(await _fetchImage());
+  }
+
+  Future<bool> delete() async {
+    await _cacheManager.open();
+    await _cacheManager.delete(_imageObject.uri);
+
+    return super.evict();
   }
 
   @override

--- a/lib/src/image_fetch_strategy.dart
+++ b/lib/src/image_fetch_strategy.dart
@@ -1,0 +1,7 @@
+enum ImageFetchStrategy {
+  // Asynchronously downloads the object at the StorageReference to a list in memory.
+  // A list of the provided max size will be allocated.
+  FETCH_TO_MEMORY,
+  // Asynchronously downloads the object to a specified system file.
+  FETCH_TO_FILE,
+}


### PR DESCRIPTION
* Allows the user to choose if they want to fetch the firebase image into memory (default) or into a file
* Allows the user the provide an optional `onError` defined as `typedef FirebaseImageError = Uint8List Function(Exception exception)`