### PR TITLE
Use const string instead of text 'table'

### DIFF
--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -44,7 +44,7 @@ class FirebaseImageCacheManager {
   }
 
   Future<FirebaseImageObject> insert(FirebaseImageObject model) async {
-    await db.insert('images', model.toMap());
+    await db.insert(table, model.toMap());
     return model;
   }
 


### PR DESCRIPTION
Uses the previously created const String 'table' instead of a newly created 'table'