### PR TITLE
implemented check meta data cycle

### DIFF
--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -19,9 +19,11 @@ class FirebaseImageCacheManager {
   late String basePath;
 
   final CacheRefreshStrategy cacheRefreshStrategy;
+  final Duration? metaDataRefreshCycle;
 
   FirebaseImageCacheManager(
     this.cacheRefreshStrategy,
+    this.metaDataRefreshCycle
   );
 
   Future<void> open() async {
@@ -34,11 +36,12 @@ class FirebaseImageCacheManager {
             remotePath TEXT, 
             localPath TEXT, 
             bucket TEXT, 
-            version INTEGER
+            version INTEGER,
+            lastMetaDataCheck INTEGER
           )
         ''');
       },
-      version: 1,
+      version: 2,
     );
     basePath = await _createFilePath();
   }
@@ -93,7 +96,15 @@ class FirebaseImageCacheManager {
           FirebaseImageObject.fromMap(maps.first);
       returnObject.reference = getImageRef(returnObject, image.firebaseApp);
       if (CacheRefreshStrategy.BY_METADATA_DATE == this.cacheRefreshStrategy) {
-        checkForUpdate(returnObject, image); // Check for update in background
+        if(this.metaDataRefreshCycle != null){ //If metaDataRefreshCycle null always checkForUpdate
+          DateTime lastMetaDataCheck = DateTime.fromMicrosecondsSinceEpoch(returnObject.lastMetaDataCheck);
+          lastMetaDataCheck.add(this.metaDataRefreshCycle!); // Add duration to lastMetaDataCheck
+          if(DateTime.now().isAfter(lastMetaDataCheck)){
+            checkForUpdate(returnObject, image); // Check for update in background
+          }
+        }else{
+          checkForUpdate(returnObject, image); // Check for update in background
+        }
       }
       return returnObject;
     }
@@ -152,6 +163,8 @@ class FirebaseImageCacheManager {
               .updated
               ?.millisecondsSinceEpoch ??
           0;
+
+      object.lastMetaDataCheck = DateTime.now().millisecondsSinceEpoch;
     }
     Uint8List? bytes = await remoteFileBytes(object, maxSizeBytes);
     await putFile(object, bytes);

--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -97,7 +97,7 @@ class FirebaseImageCacheManager {
       returnObject.reference = getImageRef(returnObject, image.firebaseApp);
       if (CacheRefreshStrategy.BY_METADATA_DATE == this.cacheRefreshStrategy) {
         if(this.metaDataRefreshCycle != null){ //If metaDataRefreshCycle null always checkForUpdate
-          DateTime lastMetaDataCheck = DateTime.fromMicrosecondsSinceEpoch(returnObject.lastMetaDataCheck);
+          DateTime lastMetaDataCheck = DateTime.fromMillisecondsSinceEpoch(returnObject.lastMetaDataCheck);
           lastMetaDataCheck.add(this.metaDataRefreshCycle!); // Add duration to lastMetaDataCheck
           if(DateTime.now().isAfter(lastMetaDataCheck)){
             checkForUpdate(returnObject, image); // Check for update in background

--- a/lib/src/firebase_image.dart
+++ b/lib/src/firebase_image.dart
@@ -22,6 +22,9 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
   /// Default: BY_METADATA_DATE. Specifies the strategy in which to check if the cached version should be refreshed (optional)
   final CacheRefreshStrategy cacheRefreshStrategy;
 
+  /// Defines in which cycle the meta data will be checked (optional)
+  final Duration? metaDataRefreshCycle;
+
   /// Default: the default Firebase app. Specifies a custom Firebase app to make the request to the bucket from (optional)
   final FirebaseApp? firebaseApp;
 
@@ -35,6 +38,7 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
   /// [scale] Default: 1.0. The scale to display the image at (optional)
   /// [maxSizeBytes] Default: 2.5MB. The maximum size in bytes to be allocated in the device's memory for the image (optional)
   /// [cacheRefreshStrategy] Default: BY_METADATA_DATE. Specifies the strategy in which to check if the cached version should be refreshed (optional)
+  /// [metaDataRefreshCycle] Defines in which cycle the meta data will be checked (optional)
   /// [firebaseApp] Default: the default Firebase app. Specifies a custom Firebase app to make the request to the bucket from (optional)
   FirebaseImage(
     String location, {
@@ -42,6 +46,7 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
     this.scale = 1.0,
     this.maxSizeBytes = 2500 * 1000, // 2.5MB
     this.cacheRefreshStrategy = CacheRefreshStrategy.BY_METADATA_DATE,
+    this.metaDataRefreshCycle,
     this.firebaseApp,
   }) : _imageObject = FirebaseImageObject(
           bucket: _getBucket(location),
@@ -74,6 +79,7 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
     Uint8List? bytes;
     FirebaseImageCacheManager cacheManager = FirebaseImageCacheManager(
       cacheRefreshStrategy,
+      metaDataRefreshCycle
     );
 
     if (shouldCache) {

--- a/lib/src/image_object.dart
+++ b/lib/src/image_object.dart
@@ -2,6 +2,7 @@ import 'package:firebase_storage/firebase_storage.dart';
 
 class FirebaseImageObject {
   int version;
+  int lastMetaDataCheck;
   Reference reference;
   String? localPath;
   final String remotePath;
@@ -10,6 +11,7 @@ class FirebaseImageObject {
 
   FirebaseImageObject({
     this.version = -1,
+    this.lastMetaDataCheck = -1,
     required this.reference,
     this.localPath,
     required this.bucket,
@@ -19,6 +21,7 @@ class FirebaseImageObject {
   Map<String, dynamic> toMap() {
     return {
       'version': this.version,
+      'lastMetaDataCheck': this.lastMetaDataCheck,
       'localPath': this.localPath,
       'bucket': this.bucket,
       'remotePath': this.remotePath,
@@ -29,6 +32,7 @@ class FirebaseImageObject {
   factory FirebaseImageObject.fromMap(Map<String, dynamic> map) {
     return FirebaseImageObject(
       version: map["version"] ?? -1,
+      lastMetaDataCheck: map["lastMetaDataCheck"] ?? -1,
       reference: map["reference"],
       localPath: map["localPath"],
       bucket: map["bucket"],


### PR DESCRIPTION
This feature is about defining a cycle in which the meta data is refreshed.
If I define it for example Duration(days: 7) then the firebase meta data only gets checked every 7 days. 

So the meta data checks can be defined more cost effective. 

If no duration is defined it checks the metadata how it was before.