### PR TITLE
Keep spaces in image path

### DIFF
--- a/lib/src/firebase_image.dart
+++ b/lib/src/firebase_image.dart
@@ -61,7 +61,7 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
 
   static String _getImagePath(String location) {
     final uri = Uri.parse(location);
-    return uri.path;
+    return uri.path.replaceAll('%20', ' ');
   }
 
   static Reference _getImageRef(String location, FirebaseApp? firebaseApp) {


### PR DESCRIPTION
If a file name of an image has spaces, the parse function will replace the spaces with '%20'. This way the reference won't be recognized by firebase. So after the parse functions I changed it back to regular spaces.