### PR TITLE
Create `Reference` in `FirebaseImageObject.fromMap` factory

### DIFF
--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -1,10 +1,8 @@
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_image/firebase_image.dart';
 import 'package:firebase_image/src/image_object.dart';
-import 'package:firebase_storage/firebase_storage.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart';
@@ -89,20 +87,13 @@ class FirebaseImageCacheManager {
     );
     if (maps.isNotEmpty) {
       FirebaseImageObject returnObject =
-          FirebaseImageObject.fromMap(maps.first);
-      returnObject.reference = getImageRef(returnObject, image.firebaseApp);
+          FirebaseImageObject.fromMap(maps.first, image.firebaseApp);
       if (CacheRefreshStrategy.BY_METADATA_DATE == cacheRefreshStrategy) {
         checkForUpdate(returnObject, image); // Check for update in background
       }
       return returnObject;
     }
     return null;
-  }
-
-  Reference getImageRef(FirebaseImageObject object, FirebaseApp? firebaseApp) {
-    FirebaseStorage storage =
-        FirebaseStorage.instanceFor(app: firebaseApp, bucket: object.bucket);
-    return storage.ref().child(object.remotePath);
   }
 
   Future<void> checkForUpdate(

--- a/lib/src/image_object.dart
+++ b/lib/src/image_object.dart
@@ -1,8 +1,9 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 
 class FirebaseImageObject {
   int version;
-  Reference reference;
+  final Reference reference;
   String? localPath;
   final String remotePath;
   final String bucket;
@@ -26,13 +27,23 @@ class FirebaseImageObject {
     };
   }
 
-  factory FirebaseImageObject.fromMap(Map<String, dynamic> map) {
+  factory FirebaseImageObject.fromMap(Map<String, dynamic> map,
+      [FirebaseApp? firebaseApp]) {
+    final String bucket = map['bucket'];
+    final String remotePath = map['remotePath'];
     return FirebaseImageObject(
       version: map["version"] ?? -1,
-      reference: map["reference"],
+      reference: _getImageRef(bucket, remotePath, firebaseApp),
       localPath: map["localPath"],
-      bucket: map["bucket"],
-      remotePath: map["remotePath"],
+      bucket: bucket,
+      remotePath: remotePath,
     );
+  }
+
+  static Reference _getImageRef(
+      String bucket, String remotePath, FirebaseApp? firebaseApp) {
+    FirebaseStorage storage =
+        FirebaseStorage.instanceFor(app: firebaseApp, bucket: bucket);
+    return storage.ref().child(remotePath);
   }
 }


### PR DESCRIPTION
This is a fix for #40.

`fromMap` assumed `map` contains a `reference` entry but this property is not actually serialized. 

This PR reconstructs a `Reference` from the other properties in `fromMap` and ensures `reference` is never `null`.