### PR TITLE
Remove obsolete null check for PaintingBinding

### DIFF
--- a/lib/src/firebase_image.dart
+++ b/lib/src/firebase_image.dart
@@ -105,7 +105,7 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
   }
 
   Future<Codec> _fetchImageCodec() async {
-    return await PaintingBinding.instance!
+    return await PaintingBinding.instance
         .instantiateImageCodec(await _fetchImage());
   }
 


### PR DESCRIPTION
PaintingBiding is null-safe. This fix should help with this warning:

Warning: Operand of null-aware operation '!' has type 'PaintingBinding' which excludes null.