### PR TITLE
remove null aware operation warning

### DIFF
--- a/lib/src/firebase_image.dart
+++ b/lib/src/firebase_image.dart
@@ -105,7 +105,7 @@ class FirebaseImage extends ImageProvider<FirebaseImage> {
   }
 
   Future<Codec> _fetchImageCodec() async {
-    return await PaintingBinding.instance!
+    return await PaintingBinding.instance
         .instantiateImageCodec(await _fetchImage());
   }
 


### PR DESCRIPTION
remove PaintBinding.instance force null to remove null aware operation warning
![Screen Shot 2022-09-01 at 12 37 50 PM](https://user-images.githubusercontent.com/20186242/187873585-44626cde-755d-446a-9a30-e8b9dee5cc2d.png)
